### PR TITLE
Missing license from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "email": "contact@bitovi.com",
     "url": "http://bitovi.com"
   },
+  "license": "MIT",
   "scripts": {},
   "main": "can-namespace",
   "keywords": [


### PR DESCRIPTION
Without a missing license in the package.json appears in audits as unlicensed